### PR TITLE
Fix memory leak and incorrect results

### DIFF
--- a/IBIS.cc
+++ b/IBIS.cc
@@ -208,7 +208,9 @@ size_t FileOrGZ<gzFile>::pfwrite(const void *ptr, size_t size, size_t n) {      
 template<>
 int FileOrGZ<FILE *>::close() {
 	assert(buf_len == 0);
-	free(buf);
+	#ifdef FORCE_FREE
+    free(buf);
+	#endif
 	return fclose(fp);
 }
 
@@ -216,7 +218,9 @@ template<>
 int FileOrGZ<gzFile>::close() {
 	if (buf_len > 0)
 		gzwrite(fp, buf, buf_len);
-	free(buf);
+	#ifdef FORCE_FREE
+    free(buf);
+	#endif
 	return gzclose(fp);
 }
 
@@ -1430,18 +1434,20 @@ int main(int argc, char **argv) {
 
 	}
 
-	delete transposedData;
+    #ifdef FORCE_FREE
+    delete transposedData;
 
-	if (bfileNameBed)
-	    delete[] bfileNameBed;
-	if (bfileNameBim)
-	    delete[] bfileNameBim;
-	if (bfileNameFam)
-	    delete[] bfileNameFam;
+    if (bfileNameBed)
+        delete[] bfileNameBed;
+    if (bfileNameBim)
+        delete[] bfileNameBim;
+    if (bfileNameFam)
+        delete[] bfileNameFam;
 
-	if (SegmentData::altMap)
-	    delete SegmentData::altMap;
+    if (SegmentData::altMap)
+        delete SegmentData::altMap;
 
-	Marker::cleanUp();
-	PersonIO<PersonLoopData>::cleanUp();
+    Marker::cleanUp();
+    PersonIO<PersonLoopData>::cleanUp();
+	#endif
 }

--- a/IBIS.cc
+++ b/IBIS.cc
@@ -208,7 +208,7 @@ size_t FileOrGZ<gzFile>::pfwrite(const void *ptr, size_t size, size_t n) {      
 template<>
 int FileOrGZ<FILE *>::close() {
 	assert(buf_len == 0);
-	// should free buf, but I know the program is about to end, so won't
+	free(buf);
 	return fclose(fp);
 }
 
@@ -216,6 +216,7 @@ template<>
 int FileOrGZ<gzFile>::close() {
 	if (buf_len > 0)
 		gzwrite(fp, buf, buf_len);
+	free(buf);
 	return gzclose(fp);
 }
 
@@ -1428,4 +1429,19 @@ int main(int argc, char **argv) {
 		}
 
 	}
+
+	delete transposedData;
+
+	if (bfileNameBed)
+	    delete[] bfileNameBed;
+	if (bfileNameBim)
+	    delete[] bfileNameBim;
+	if (bfileNameFam)
+	    delete[] bfileNameFam;
+
+	if (SegmentData::altMap)
+	    delete SegmentData::altMap;
+
+	Marker::cleanUp();
+	PersonIO<PersonLoopData>::cleanUp();
 }

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,20 @@ ifdef PROFILE       # to use run `make PROFILE=1
   CFLAGS += -pg
 endif
 
+# force memory freeing
+ifdef FORCE_FREE
+  CFLAGS += -DFORCE_FREE
+endif
+
+# shared
+ifdef SHARED
+  ifndef FORCE_FREE
+    CFLAGS += -DFORCE_FREE
+  endif
+  CFLAGS += -fPIC
+  CFLAGS += --no-gnu-unique
+endif
+
 LIBS= -lz
 ifdef RELEASE
   LIBS += -static-libstdc++ -static-libgcc
@@ -76,3 +90,6 @@ clean:
 
 clean-deps:
 	rm -f $(DEPDIR)/*.P
+
+libibis.so: $(OBJS) $(HEADERS)
+	$(GPP) -o "$@" $(OBJS) -shared $(CFLAGS) $(LIBS)


### PR DESCRIPTION
Hello! We are working with IBIS as shared library and we found two problems.
First is memory leaks, code really depends on OS to clear the memory but in our case (shared library) process doesn't stop, so memory is not freed.
Second problem is incorrect results, some collections are not cleared and it leads to `Parsing SNP file... ERROR: some markers have non-zero genetic position and cannot be used`.

This code also depends on fix for genetio, so in case of acceptance please accept genetio fix first: https://github.com/williamslab/genetio/pull/3

For correct results and zero memory leak we used this test code.

Makefile additions
```makefile
CFLAGS = -I. -Wall $(DEFINES) -fopenmp -mpopcnt -fPIC --no-gnu-unique
#...
libibis.so: $(OBJS) $(HEADERS)
	$(GPP) -o "$@" $(OBJS) -shared $(CFLAGS) $(LIBS)
```

Test itself
```python
import ctypes

file = './libibis.so'  # your .so file

merged_dataset = ['dataset/dataset.bed', 'dataset/dataset_mapped.bim', 'dataset/dataset.fam']
options = ['-t', '1', '-mt', '560', '-mL', '7', '-ibd2', '-mL2', '3', '-hbd', '-setIndexStart', '0']

args = ['ibis']
args.extend(merged_dataset)
args.extend(options)
args.extend(['-f', 'results/results'])
print(' '.join(args))
args = [arg.encode() for arg in args]
argc = len(args)
args = (ctypes.c_char_p * argc)(*args)


cdll = ctypes.CDLL(file)

import os, psutil
process = psutil.Process(os.getpid())

memory_data = {}

for i in range(20):
    cdll.main(argc, args)
    memory_data[i+1] = process.memory_info().rss // (1024 ** 2)
    # optional clearing step
    libdl = ctypes.CDLL(None)
    libdl.close(cdll._handle)
    cdll = ctypes.CDLL(file)

for k, v in memory_data.items():
    print(f'Step {k}: {v}Mb. +{v-memory_data.get(k-1, 0)}Mb')
```


